### PR TITLE
close #9 - support for onion v3 secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ onion_services:
      onion_hostname:
      onion_version: 3
      onion_ports:
-        - [25, 25] 
+        - [25, 25]
         - [587,587]
-     onion_private_key:
-
+     onion_private_key_b64encoded: |
+      here goes the file hs_ed25519_secret_key encoded in base 64
 
 #
 # Example for torrc with special onion configurations
@@ -149,7 +149,7 @@ Testing
 
 Run local tests with:
 ```
-molecule test 
+molecule test
 ```
 Requires Molecule, Vagrant and `python-vagrant` to be installed.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
         item.value.onion_state|default('present') == 'present'
   notify: reload tor
 
-- name: ensure private_key file are present
+- name: ensure private_key file are present (for onion v2)
   template:
     src: private_key
     dest: "/var/lib/tor/{{ item.key }}/private_key"
@@ -94,6 +94,23 @@
   with_dict: "{{ onion_services }}"
   when: item.value.onion_private_key is defined and
         item.value.onion_private_key and
+        item.value.onion_version|default(2) == 2 and
+        item.value.onion_state|default('present') == 'present'
+  notify: reload tor
+
+- name: copy encoded private_key (only for onion v3)
+  template:
+    src: private_key_encoded
+    dest: "/var/lib/tor/{{ item.key }}/hs_ed25519_secret_key"
+    owner: debian-tor
+    group: debian-tor
+    mode: 0600
+    backup: yes
+  with_dict: "{{ onion_services }}"
+  when: item.value.onion_private_key_b64encoded is defined and
+        item.value.onion_private_key_b64encoded and
+        item.value.onion_version is defined and
+        item.value.onion_version == 3 and
         item.value.onion_state|default('present') == 'present'
   notify: reload tor
 

--- a/templates/private_key_encoded
+++ b/templates/private_key_encoded
@@ -1,0 +1,1 @@
+{{ item.value.onion_private_key_b64encoded | b64decode }}


### PR DESCRIPTION
Onion v3 private keys are stored in the binary form on the file
hs_ed25519_secret_key, which makes it impractical to write in a
variable. The solution was to define it in base64.

It should be noted that this will break if the file
'private_key_encoded' is opened in a common text editor and saved,
as some modern editors add a trailing '\n' to the file automatically.
As that would change the value stored in key file.

The PR probably still requires some modifications to the tests and better
documentation in order to make the user of the role well aware that the key
should be base64 encoded