### PR TITLE
Remove support for onion services in version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Hint: It may take up to one minute, until the service is announced in the tor ne
 
 Be careful: Using the default 127.0.0.1 as Onion Service IP-address could possibly leak meta data: https://help.riseup.net/en/security/network-security/tor/onionservices-best-practices#be-careful-of-localhost-bypasses
 
-Supports [Next Gen Onion Services](https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions#Howtosetupyourownprop224service) only if tor version >= [0.3.2.1](https://blog.torproject.org/tor-0321-alpha-released-support-next-gen-onion-services-and-kist-scheduler)!
-Since Tor 0.3.5.0 HiddenServices v3 is the default. You have to set `onion_version: 2` if you want to use former onion services.
+Only supports Onion Services in version 3 previously known as [Next Gen Onion Services](https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions#Howtosetupyourownprop224service) only if tor version >= [0.3.2.1](https://blog.torproject.org/tor-0321-alpha-released-support-next-gen-onion-services-and-kist-scheduler)!
+
+Version 2 Onion Services are currently in a [deprecation phase](https://blog.torproject.org/v2-deprecation-timeline).
+If you need an v2 onion service, please use a previous release of this role!
 
 Role Variables
 --------------
@@ -66,46 +68,8 @@ onion_active: True
 onion_ipaddr: 192.168.3.12
 
 onion_services:
-  ssh:
-     onion_hostname:
-     onion_version: 2
-     onion_ports:
-        - [22, 22]
-     onion_private_key:
-  mail:
-     onion_hostname:
-     onion_version: 2
-     onion_ports:
-        - [25, 25] #[redirected_from, redirected_to]
-        - [587,587]
-     onion_private_key:
-  examplewithhostname:
-     onion_hostname: onionurl.onion
-     onion_version: 2
-     onion_ports:
-        - [25, 25]
-        - [587,587]
-     onion_private_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      the
-      private
-      key
-      -----END RSA PRIVATE KEY-----
-  absentonion:
-     onion_state: absent
-     onion_version: 2
-     onion_hostname: onionurl.onion
-     onion_ports:
-        - [25, 25]
-        - [587,587]
-     onion_private_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      the
-      private
-      key
-      -----END RSA PRIVATE KEY-----
   #
-  # nextgeneration onion only available in tor >= 0.3.2.1
+  # nextgeneration onion (v3) only available in tor >= 0.3.2.1
   # https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions#Howtosetupyourownprop224service
   #
   nextgenonion:
@@ -115,7 +79,15 @@ onion_services:
         - [587,587]
      onion_public_key_b64encoded: "\nPT0gZWQyNTUxOaYxLXB1YmxpYzogdHlwZTAgPT0AAABADSX6gVbfuClP6aBXz8V00oMw5Sovn0ZU\nftKei9UWmw==\n"
      onion_secret_key_b64encoded: "\nPT0gZWQyNTUxOaYxLXNlY3JldDogdHlwZTAgPT0AAAAYzbVMulElZeorlRoSKWG4VVVwWQN0lHac\nhpR5jLcqb2iuHQu7K9yrdRUrSUWW42gFUvl7lCDQPV7aGWQcf9TI\n"
-    
+
+  absentonion:
+     onion_state: absent
+     onion_hostname: onionv3url.onion
+     onion_ports:
+        - [25, 25]
+        - [587,587]
+     onion_public_key_b64encoded: "\nPT0gZWQyNTUxOaYxLXB1YmxpYzogdHlwZTAgPT0AAABADSX6gVbfuClP6aBXz8V00oMw5Sovn0ZU\nftKei9UWmw==\n"
+     onion_secret_key_b64encoded: "\nPT0gZWQyNTUxOaYxLXNlY3JldDogdHlwZTAgPT0AAAAYzbVMulElZeorlRoSKWG4VVVwWQN0lHac\nhpR5jLcqb2iuHQu7K9yrdRUrSUWW42gFUvl7lCDQPV7aGWQcf9TI\n"
 
 #
 # Example for torrc with special onion configurations
@@ -160,7 +132,7 @@ For developing and testing the role we use Github Actions, Molecule, and Vagrant
 Run local tests with:
 
 ```
-molecule test 
+molecule test
 ```
 
 License

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,12 +6,6 @@ driver:
 platforms:
   - name: buster64
     box: debian/buster64
-#  - name: stretch64
-#    box: debian/stretch64
-#  - name: jessie64
-#    box: debian/jessie64
-#  - name: xenial64
-#    box: ubuntu/xenial64
 #  - name: bionic64
 #    box: ubuntu/bionic64
 lint: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for onion
-
 - name: Ensure gpg is present
   apt:
     pkg: gnupg
@@ -30,18 +28,6 @@
   apt:
     pkg: tor
     state: "{{ onion_tor_apt_state }}"
-
-#
-# - removed trailing 0: 0.3.2.1 --> 3.2.1
-# - jinja2 filter compare version is allowing max. two dots (https://pizjix.com/version-numbers-in-ansible-code/)
-# - comparision is needed as safety, to not deploy onions in version 3,
-#   if the tor version does not support it
-#
-- name: register version of tor
-  shell: "executable=/bin/bash set -o pipefail && tor --version | cut -d' ' -f3 | cut -d. -f2- | sed 's/\\.$//'"
-  register: tor_version
-  check_mode: no
-  changed_when: false
 
 - name: install extra tor packages
   apt:
@@ -83,22 +69,6 @@
     - item.value.onion_state|default('present') == 'present'
   notify: restart tor
 
-- name: ensure private_key file are present (for onion v2)
-  template:
-    src: private_key.j2
-    dest: "/var/lib/tor/{{ item.key }}/private_key"
-    owner: debian-tor
-    group: debian-tor
-    mode: 0600
-    backup: yes
-  with_dict: "{{ onion_services }}"
-  when:
-    - item.value.onion_private_key is defined
-    - item.value.onion_private_key
-    - item.value.onion_version|default(3) == 2
-    - item.value.onion_state|default('present') == 'present'
-  notify: restart tor
-
 - name: copy encoded public_key (only for onion v3)
   shell: "executable=/bin/bash set -o pipefail &&\
 echo \"{{ item.value.onion_public_key_b64encoded }}\" | base64 -d >/var/lib/tor/{{ item.key }}/hs_ed25519_public_key"
@@ -108,7 +78,6 @@ echo \"{{ item.value.onion_public_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - item.value.onion_public_key_b64encoded is defined
     - item.value.onion_public_key_b64encoded
-    - item.value.onion_version|default(3) == 3
     - item.value.onion_state|default('present') == 'present'
   notify: restart tor
 
@@ -122,7 +91,6 @@ echo \"{{ item.value.onion_public_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - item.value.onion_public_key_b64encoded is defined
     - item.value.onion_public_key_b64encoded
-    - item.value.onion_version|default(3) == 3
     - item.value.onion_state|default('present') == 'present'
 
 - name: copy encoded secret_key (only for onion v3)
@@ -134,7 +102,6 @@ echo \"{{ item.value.onion_secret_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - item.value.onion_secret_key_b64encoded is defined
     - item.value.onion_secret_key_b64encoded
-    - item.value.onion_version|default(3) == 3
     - item.value.onion_state|default('present') == 'present'
   notify: restart tor
 
@@ -148,25 +115,22 @@ echo \"{{ item.value.onion_secret_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - item.value.onion_secret_key_b64encoded is defined
     - item.value.onion_secret_key_b64encoded
-    - item.value.onion_version|default(3) == 3
     - item.value.onion_state|default('present') == 'present'
 
 - name: ensure onion directory is absent
   file:
     path: "/var/lib/tor/{{ item.key }}/"
-    owner: debian-tor
-    group: debian-tor
     mode: 0700
     state: absent
   with_dict: "{{ onion_services }}"
   when: item.value.onion_state|default('present') == "absent"
 
 # The hostname file won't be created until the tor service
-# is reloaded, so bounce it before the `wait_for` task.
+# is restarted, so bounce it before the `wait_for` task.
 - name: restart tor if service was created
   service:
     name: tor
-    state: reloaded
+    state: restarted
   when: onion_directory_creation_result is changed
 
 - name: wait for onion
@@ -192,7 +156,6 @@ echo \"{{ item.value.onion_secret_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - not item.value.onion_secret_key_b64encoded|default(false)
     - item.value.onion_state|default('present') != "absent"
-    - item.value.onion_version|default(3) == 3
 
 - name: read onion v3 public key
   command: base64 "/var/lib/tor/{{ item.key }}/hs_ed25519_public_key"
@@ -202,7 +165,6 @@ echo \"{{ item.value.onion_secret_key_b64encoded }}\" | base64 -d >/var/lib/tor/
   when:
     - not item.value.onion_public_key_b64encoded|default(false)
     - item.value.onion_state|default('present') != "absent"
-    - item.value.onion_version|default(3) == 3
 
 - name: display onion url
   debug:

--- a/templates/private_key.j2
+++ b/templates/private_key.j2
@@ -1,1 +1,0 @@
-{{ item.value.onion_private_key }}

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -79,12 +79,7 @@ HidServAuth {{ client }}
 {% for servicename, hsproperties in onion_services|dictsort %}
 {% if hsproperties['onion_state']|default('present') != 'absent' %}
 HiddenServiceDir /var/lib/tor/{{ servicename }}/
-{% if hsproperties['onion_version']|default(2) == 3 and tor_version.stdout is version_compare('3.2.1', '>=', strict=True) and tor_version.stdout is version_compare('3.2.5', '<', strict=True) %}
 HiddenServiceVersion 3
-{% endif %}
-{% if hsproperties['onion_version']|default(3) == 2 and tor_version.stdout is version_compare('3.2.5', '>=', strict=True) %}
-HiddenServiceVersion 2
-{% endif %}
 {% for port in hsproperties['onion_ports'] %}
 HiddenServicePort {{ port.0 }} {{ onion_ipaddr }}:{{ port.1}}
 {% endfor %}


### PR DESCRIPTION
Since onion services in version 2 are in a [deprecation phase out](https://blog.torproject.org/v2-deprecation-timeline), this role shouldn't support them anymore. 