### PR TITLE
Remove HiddenServiceVersion parameter, it's 3 per default

### DIFF
--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -79,7 +79,6 @@ HidServAuth {{ client }}
 {% for servicename, hsproperties in onion_services|dictsort %}
 {% if hsproperties['onion_state']|default('present') != 'absent' %}
 HiddenServiceDir /var/lib/tor/{{ servicename }}/
-HiddenServiceVersion 3
 {% for port in hsproperties['onion_ports'] %}
 HiddenServicePort {{ port.0 }} {{ onion_ipaddr }}:{{ port.1}}
 {% endfor %}


### PR DESCRIPTION
Removes unecessary HiddenServiceVersion parameter from torrc. It's 3 per default an does not need to be templated