### PR TITLE
Add Onion Proof of Work capability

### DIFF
--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -82,7 +82,18 @@ HiddenServiceDir /var/lib/tor/{{ servicename }}/
 {% for port in hsproperties['onion_ports'] %}
 HiddenServicePort {{ port.0 }} {{ onion_ipaddr }}:{{ port.1}}
 {% endfor %}
-
+{% if hsproperties['onion_hidden_service_pow_defenses_enabled'] is defined %}
+HiddenServicePoWDefensesEnabled {{ hsproperties['onion_hidden_service_pow_defenses_enabled'] }}
+{% endif %}
+{% if hsproperties['onion_hidden_service_pow_queue_rate'] is defined %}
+HiddenServicePoWQueueRate {{ hsproperties['onion_hidden_service_pow_queue_rate'] }}
+{% endif %}
+{% if hsproperties['onion_hidden_service_pow_queue_burst'] is defined %}
+HiddenServicePoWQueueBurst {{ hsproperties['onion_hidden_service_pow_queue_burst'] }}
+{% endif %}
+{% if hsproperties['onion_compiled_proof_of_work_hash'] is defined %}
+CompiledProofOfWorkHash {{ hsproperties['onion_compiled_proof_of_work_hash'] }}
+{% endif %}
 {% endif %}
 {% for client in hsproperties['onion_authorized_clients']|default([]) %}
 HiddenServiceAuthorizeClient stealth {{ client }}


### PR DESCRIPTION
Hi,

Thanks for this role!

This adds the ability configure [Onion Proof Of Work](https://onionservices.torproject.org/technology/security/pow/#how-to-enable-this-as-a-service-operator) for an onion service.

Thanks again.